### PR TITLE
Update _withdrawal_notification-email.html

### DIFF
--- a/templates/careers/application/_withdrawal_notification-email.html
+++ b/templates/careers/application/_withdrawal_notification-email.html
@@ -1,7 +1,8 @@
 <div>
   <p>Dear {{ hiring_lead_name }},</p>
-  <p>This is an automated email is to inform you that {{ applicant_name }} has withdrawn their application for the {{ position }} position.</p>
+  <p>This is an automated email to inform you that {{ applicant_name }} has withdrawn their application for the {{ position }} position.</p>
   <p>The candidate was in {{ current_stage["name"] }} stage.</p>
+  <p>If this is an interview stage, please make sure you check the activity feed of the candidate in Greenhouse and delete any pending interviews directly from Google Calendar.</p>
   <p><a href="{{application_url}}">Click here to access the candidate's application.</a></p>
   <p>Regards,<br>Talent Science Engineering</p>
 </div>


### PR DESCRIPTION
Added a line to remind Hiring Leads to cancel pending interviews.

## Done

- Added a line to remind Hiring Leads to manually cancel any pending interviews if the candidate withdraws.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
